### PR TITLE
Add `mozilla::dom::ToJSValue` to the prefix list

### DIFF
--- a/socorro/signature/siglists/prefix_signature_re.txt
+++ b/socorro/signature/siglists/prefix_signature_re.txt
@@ -157,6 +157,7 @@ mozilla::CondVar::
 mozilla::detail::ConditionVariableImpl::
 mozilla::detail::HashTable<.*>::
 mozilla::detail::nsTStringRepr<T>::
+mozilla::dom::ToJSValue
 mozilla::DOMEventTargetHelper::AddRef
 mozilla::MozPromise<T>::ThenCommand<T>::Track
 mozilla::MozPromise<T>::ThenInternal


### PR DESCRIPTION
See for example [bug 1725107](https://bugzilla.mozilla.org/show_bug.cgi?id=1725107) where some of the linked crashes are associated with the comment #0 crash report, but others are not.